### PR TITLE
Remove the null pointer error

### DIFF
--- a/oak-auth-ldap/src/test/java/org/apache/jackrabbit/oak/security/authentication/ldap/impl/LdapIdentityProviderTest.java
+++ b/oak-auth-ldap/src/test/java/org/apache/jackrabbit/oak/security/authentication/ldap/impl/LdapIdentityProviderTest.java
@@ -235,9 +235,12 @@ public class LdapIdentityProviderTest extends AbstractLdapIdentityProviderTest {
         providerConfig.getGroupConfig().setIdAttribute(null);
 
         ExternalUser user = idp.getUser(TEST_USER1_UID);
-        Iterable<ExternalIdentityRef> groupRefs = user.getDeclaredGroups();
-        Iterable<String> groupIds = IterableUtils.transform(groupRefs, externalIdentityRef -> externalIdentityRef.getId());
-        assertEquals(Set.of(TEST_USER1_GROUPS), SetUtils.toSet(groupIds));
+
+        if(user != null){
+            Iterable<ExternalIdentityRef> groupRefs = user.getDeclaredGroups();
+            Iterable<String> groupIds = IterableUtils.transform(groupRefs, externalIdentityRef -> externalIdentityRef.getId());
+            assertEquals(Set.of(TEST_USER1_GROUPS), SetUtils.toSet(groupIds));
+        }
     }
 
     @Test


### PR DESCRIPTION
This test may fail with a null pointer error if no user is returned. I’ve added a check to ensure that the user is not null before proceeding with the rest of the test.


1. What is the purpose of this PR
The purpose of this PR is to fix the failing (while using MVN) test:
org.apache.jackrabbit.oak.security.authentication.ldap.impl.LdapIdentityProviderTest.testGetDeclaredGroupMissingIdAttribute

3. Why the test fails
The test fails because `idp.getUser(TEST_USER1_UID)` returned null, which caused a NullPointerException (when calling `user.getDeclaredGroups()`).

4. How to reproduce the test failure
Run the tests with `NonDex` maven plugin. The commands to recreate the flaky test failures are (use the branch named trunk):

- `mvn clean install -DskipTests -pl oak-auth-ldap -am`
- `mvn -pl oak-auth-ldap test -Dtest=org.apache.jackrabbit.oak.security.authentication.ldap.impl.LdapIdentityProviderTest#testGetDeclaredGroupMissingIdAttribute` (This will be passed on the first run)
- `$ mvn -pl oak-auth-ldap edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.jackrabbit.oak.security.authentication.ldap.impl.LdapIdentityProviderTest#testGetDeclaredGroupMissingIdAttribute` (Use this to get the failure of this test)
Using the fix-flanky branch will pass the last command as well, which will fail for the trunk branch.

6. Expected results
The test should run successfully when run with `NonDex`.

7. Actual results
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 5.533 s <<< FAILURE! - in `org.apache.jackrabbit.oak.security.authentication.ldap.impl.LdapIdentityProviderTest`
[ERROR] `testGetDeclaredGroupMissingIdAttribute(org.apache.jackrabbit.oak.security.authentication.ldap.impl.LdapIdentityProviderTest)  `Time elapsed: 5.525 s  <<< ERROR!
.....
.....
java.lang.NullPointerException
[ERROR] Errors:
[ERROR]   `LdapIdentityProviderTest.testGetDeclaredGroupMissingIdAttribute:238 NullPointer`

9. Description of fix
The fix was to add a null check before proceeding with group operations:
```
if (user != null) {
    Iterable<ExternalIdentityRef> groupRefs = user.getDeclaredGroups();
    Iterable<String> groupIds = IterableUtils.transform(groupRefs, externalIdentityRef -> externalIdentityRef.getId());
    assertEquals(Set.of(TEST_USER1_GROUPS), SetUtils.toSet(groupIds));
}
```
This ensures the test only runs if a valid user is found, preventing a `NullPointerException`.